### PR TITLE
chore: Add eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "airbnb/base",
+  "rules": {
+    "indent": ["error", 4]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   },
   "devDependencies": {
     "del": "^2.2.1",
+    "eslint": "^3.3.1",
+    "eslint-config-airbnb": "^10.0.1",
+    "eslint-plugin-import": "^1.13.0",
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-connect": "^4.1.0",
     "gulp-rollup": "^2.2.0",


### PR DESCRIPTION
Add `eslint`, use AirBnB's eslint config with (so far) 1 minor change (indentation level).

The AirBnB eslint dependency complains about some unmet peer dependencies around React and JSX. Maybe we just clone their setup rather than importing it and rip out the React-specific stuff?

Closes #2 
